### PR TITLE
fix: Update copyright year and owner in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2025 Axel Omar Sanchez Peralta
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request updates the copyright notice in the `LICENSE` file to reflect the current year and the correct copyright owner.

* Updated the copyright year to 2025 and set the copyright owner to "Axel Omar Sanchez Peralta" in the `LICENSE` file.